### PR TITLE
修复ginkgo插件中存在的已知问题

### DIFF
--- a/ginkgo/pkg/cmdline/arg.go
+++ b/ginkgo/pkg/cmdline/arg.go
@@ -59,6 +59,9 @@ func NewCmdArgsParseByCmdLine(cmdline string) (*CommandArgs, error) {
 			cmdArgs = append(cmdArgs, &CommandArg{Key: key, Value: value})
 		}
 	}
+	if strings.HasSuffix(args[len(args)-1], ".test") {
+		cmdArgs = append(cmdArgs, &CommandArg{Key: "", Value: args[len(args)-1]})
+	}
 	return &CommandArgs{cmdArgs}, nil
 }
 

--- a/ginkgo/pkg/loader/load.go
+++ b/ginkgo/pkg/loader/load.go
@@ -25,7 +25,7 @@ func LoadTestCase(projPath string, selectorPath string) ([]*ginkgoTestcase.TestC
 	parseMode := os.Getenv("TESTSOLAR_TTP_PARSEMODE")
 	log.Printf("Try to load testcases from path %s, parse mode: %s", selectorAbsPath, parseMode)
 	if fi.IsDir() {
-		if parseMode == "dynamic" {
+		if parseMode != "static" {
 			loadedTestCases, lErrors := DynamicLoadTestcaseInDir(projPath, selectorAbsPath)
 			testcaseList = append(testcaseList, loadedTestCases...)
 			loadErrors = append(loadErrors, lErrors...)
@@ -41,7 +41,7 @@ func LoadTestCase(projPath string, selectorPath string) ([]*ginkgoTestcase.TestC
 			}
 		}
 	} else {
-		if parseMode == "dynamic" {
+		if parseMode != "static" {
 			loadedTestCases, lErrors := DynamicLoadTestcaseInFile(projPath, selectorAbsPath)
 			testcaseList = append(testcaseList, loadedTestCases...)
 			loadErrors = append(loadErrors, lErrors...)

--- a/ginkgo/pkg/loader/load_test.go
+++ b/ginkgo/pkg/loader/load_test.go
@@ -11,6 +11,8 @@ import (
 
 func TestLoadTestCase(t *testing.T) {
 	// test static loading testcase in directory
+	err := os.Setenv("TESTSOLAR_TTP_PARSEMODE", "static")
+	assert.NoError(t, err)
 	absPath, err := filepath.Abs("../../testdata/")
 	assert.NoError(t, err)
 	testcases, loadErrors := LoadTestCase(absPath, "demo")

--- a/ginkgo/pkg/result/result_test.go
+++ b/ginkgo/pkg/result/result_test.go
@@ -37,7 +37,7 @@ func TestParseJsonToObj(t *testing.T) {
 	results, err = parser.Parse()
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
-	if results[0].Test.Name != "suites/demo/demo_suite_test.go?HierarchyText01 HierarchyText02 Text [label01, label02, label11, node-label01]" {
+	if results[0].Test.Name != "suites/demo/demo_suite_test.go?HierarchyText01 HierarchyText02/Text [label01, label02, label11, node-label01]" {
 		t.Errorf("incorrect case name: %s", results[0].Test.Name)
 	}
 

--- a/ginkgo/pkg/runner/runner_test.go
+++ b/ginkgo/pkg/runner/runner_test.go
@@ -25,6 +25,9 @@ func TestGenarateCommandLine(t *testing.T) {
 	expected := `ginkgo --v --no-color --trace --json-report "output.json" --output-dir "/data/workspace" --always-emit-ginkgo-writer --procs "3" --timeout "5h" --focus "case" --label-filter "( label01||label02)" suite.test`
 	cmdline := genarateCommandLine(extraArgs, jsonFileName, projPath, pkgBin, tcNames, true)
 	assert.Equal(t, expected, cmdline, "should return the expected command line")
+	extraArgs = "b64://LS1wcm9jcyAzIC0tdGltZW91dCA1aCAtLWZvY3VzICJjYXNlIiAtLWxhYmVsLWZpbHRlciAiKCBsYWJlbDAxfHxsYWJlbDAyKSIgLS10aW1lb3V0IDVoIA=="
+	cmdline = genarateCommandLine(extraArgs, jsonFileName, projPath, pkgBin, tcNames, true)
+	assert.Equal(t, expected, cmdline, "should return the expected command line")
 }
 
 func Test_obtainExpectedExecuteCases(t *testing.T) {
@@ -37,7 +40,7 @@ func Test_obtainExpectedExecuteCases(t *testing.T) {
 	_, err = os.Stat(pkgBin)
 	assert.NoError(t, err)
 	defer os.Remove(pkgBin)
-	cmdline := fmt.Sprintf("ginkgo --v --no-color --procs 10 --always-emit-ginkgo-writer -p %s", pkgBin)
+	cmdline := fmt.Sprintf("ginkgo --v --no-color --procs 10 --always-emit-ginkgo-writer %s", pkgBin)
 	err = os.Setenv("TESTSOLAR_TTP_EXTRAARGS", "1")
 	assert.NoError(t, err)
 	expectedCases := obtainExpectedExecuteCasesByDryRun(projPath, cmdline)
@@ -54,7 +57,7 @@ func Test_getExpectedCases(t *testing.T) {
 	_, err = os.Stat(pkgBin)
 	assert.NoError(t, err)
 	defer os.Remove(pkgBin)
-	cmdline := fmt.Sprintf("ginkgo --v --no-color --procs 10 --always-emit-ginkgo-writer -p %s", pkgBin)
+	cmdline := fmt.Sprintf("ginkgo --v --no-color --procs 10 --always-emit-ginkgo-writer %s", pkgBin)
 	err = os.Setenv("TESTSOLAR_TTP_EXTRAARGS", "1")
 	assert.NoError(t, err)
 	expectedCases := getExpectedCases(cmdline, projPath, "tests/ginkgo/demo/demo_test.go", "tests/ginkgo/demo", []string{})
@@ -80,7 +83,7 @@ func Test_convertExpectedCasesToFailedCases(t *testing.T) {
 }
 
 func Test_regenerateDryRunCmd(t *testing.T) {
-	dryRunCmd, err := regenerateDryRunCmd(`ginkgo --v --no-color --trace --json-report output.json --output-dir /data/workspace --always-emit-ginkgo-writer --procs "10" --timeout "5h" --label-filter "(label01)" -p /data/workspace`)
+	dryRunCmd, err := regenerateDryRunCmd(`ginkgo --v --no-color --trace --json-report output.json --output-dir /data/workspace --always-emit-ginkgo-writer --procs "10" --timeout "5h" --label-filter "(label01)" /data/workspace.test`)
 	assert.NoError(t, err)
-	assert.Equal(t, dryRunCmd, `ginkgo --v --no-color --trace --json-report "output.json" --output-dir "/data/workspace" --timeout "5h" --label-filter "(label01)" --dry-run "/data/workspace"`)
+	assert.Equal(t, dryRunCmd, `ginkgo --dry-run --v --no-color --trace --json-report "output.json" --output-dir "/data/workspace" --timeout "5h" --label-filter "(label01)" /data/workspace.test`)
 }


### PR DESCRIPTION
1. 默认加载方式更改为动态加载
2. 支持base64解码传入的额外参数环境变量
3. 修复执行用例输出结果json文件的bug
4. 修复解析额外参数的bug