### PR TITLE
增加ginkgo插件功能

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -28,7 +28,6 @@ jobs:
           sudo apt-get install -y upx
       - name: Get dependencies
         run: |
-          cd ginkgo
           go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
           go mod download
       - name: golangci-lint

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -28,7 +28,7 @@ jobs:
           sudo apt-get install -y upx
       - name: Get dependencies
         run: |
-          go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+          go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.20.1
           go mod download
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/ginkgo/pkg/loader/dynamic_loader.go
+++ b/ginkgo/pkg/loader/dynamic_loader.go
@@ -158,7 +158,14 @@ func getAvailableSuitePath(projPath, rootPath string) ([]string, error) {
 			if packagePath == projPath {
 				packagePath = ""
 			} else {
-				packagePath = packagePath[len(projPath)+1:]
+				if relPath, err := filepath.Rel(projPath, packagePath); err != nil {
+					log.Printf("get rel path failed, basepath %s, targpath: %s, err: %v", projPath, packagePath, err)
+					relPath = strings.TrimPrefix(packagePath, projPath)
+					relPath = strings.TrimPrefix(relPath, "/")
+					packagePath = relPath
+				} else {
+					packagePath = relPath
+				}
 			}
 			if !ginkgoUtil.ElementIsInSlice(packagePath, packageList) {
 				packageList = append(packageList, packagePath)

--- a/ginkgo/pkg/loader/dynamic_loader.go
+++ b/ginkgo/pkg/loader/dynamic_loader.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	ginkgoBuilder "github.com/OpenTestSolar/testtool-golang-ginkgo/ginkgo/pkg/builder"
 	ginkgoResult "github.com/OpenTestSolar/testtool-golang-ginkgo/ginkgo/pkg/result"
-
 	ginkgoTestcase "github.com/OpenTestSolar/testtool-golang-ginkgo/ginkgo/pkg/testcase"
 	ginkgoUtil "github.com/OpenTestSolar/testtool-golang-ginkgo/ginkgo/pkg/util"
 
@@ -50,23 +51,25 @@ func ginkgo_v1_load(projPath, pkgBin string, ginkgoVersion int) ([]*ginkgoTestca
 
 func ginkgo_v2_load(projPath, path, pkgBin string, ginkgoVersion int) ([]*ginkgoTestcase.TestCase, error) {
 	var caseList []*ginkgoTestcase.TestCase
-	reportJson := filepath.Join(path, "report.json")
-	if exists, err := ginkgoUtil.FileExists(reportJson); err != nil || exists {
-		if err != nil {
-			log.Printf("Check report.json file exists failed: %v", err)
+	var cmdline string
+	var workDir string
+	if pkgBin != "" {
+		cmdline = strings.Join([]string{pkgBin, "--ginkgo.v --ginkgo.dry-run --ginkgo.no-color --ginkgo.json-report=report.json"}, " ")
+		workDir = projPath
+	} else {
+		if _, err := exec.LookPath("ginkgo"); err != nil {
+			return nil, errors.Wrapf(err, "there is no test and ginkgo binary")
 		}
-		err := os.Remove(reportJson)
-		if err != nil {
-			log.Printf("Remove report.json file failed: %v", err)
-		}
+		cmdline = "ginkgo --v --dry-run --no-color --json-report=report.json ."
+		workDir = filepath.Join(projPath, path)
 	}
-	cmdline := pkgBin + fmt.Sprintf(" --ginkgo.v --ginkgo.dry-run --ginkgo.no-color --ginkgo.json-report=%s ", reportJson)
-	log.Printf("dry run cmd: %s", cmdline)
-	output, _, err := ginkgoUtil.RunCommandWithOutput(cmdline, projPath)
+	log.Printf("dry run cmd: %s\nwork directory: %s", cmdline, workDir)
+	output, _, err := ginkgoUtil.RunCommandWithOutput(cmdline, workDir)
 	if err != nil {
 		log.Printf("Ginkgo v2 dry run command exit code: %v", err)
 		return nil, err
 	}
+	reportJson := filepath.Join(workDir, "report.json")
 	if exists, err := ginkgoUtil.FileExists(reportJson); err != nil || !exists {
 		log.Printf("dry run report json file not exists, try to parse cases by stdout")
 		testcaseList, errInfo := ginkgoResult.ParseCaseByReg(projPath, output, ginkgoVersion, path)
@@ -117,8 +120,12 @@ func dynamicLoadTestcase(projPath string, selectorPath string) ([]*ginkgoTestcas
 	absSelectorPath := filepath.Join(projPath, selectorPath)
 	pkgBin := findBinFile(absSelectorPath)
 	if pkgBin == "" {
-		log.Printf("package bin file not exist, ignore load testcase")
-		return caseList, nil
+		log.Printf("Can't find package bin file %s during loading, try to build it...", pkgBin)
+		var err error
+		pkgBin, err = ginkgoBuilder.BuildTestPackage(projPath, selectorPath, false)
+		if err != nil {
+			log.Printf("Build package %s during loading failed, err: %s", selectorPath, err.Error())
+		}
 	}
 	ginkgoVersion := ginkgoUtil.FindGinkgoVersion(absSelectorPath)
 	log.Printf("load testcase by bin file %s under ginkgo %d", pkgBin, ginkgoVersion)

--- a/ginkgo/pkg/runner/v2_runner.go
+++ b/ginkgo/pkg/runner/v2_runner.go
@@ -50,7 +50,7 @@ func genarateCommandLine(extraArgs, jsonFileName, projPath, pkgBin string, tcNam
 		cmdline := cmdArgs.GenerateCmdLineStr()
 		return cmdline
 	} else {
-		return pkgBin + fmt.Sprintf(` --ginkgo.v --ginkgo.no-color --ginkgo.trace --ginkgo.json-report="%s" --ginkgo.always-emit-ginkgo-writer --ginkgo.focus="%s$"`, jsonFileName, cmdpkg.GenTestCaseFocusName(tcNames, false))
+		return pkgBin + fmt.Sprintf(` --ginkgo.v --ginkgo.no-color --ginkgo.trace --ginkgo.json-report="%s" --ginkgo.always-emit-ginkgo-writer --ginkgo.focus="%s"`, jsonFileName, cmdpkg.GenTestCaseFocusName(tcNames, false))
 	}
 }
 

--- a/ginkgo/pkg/util/common.go
+++ b/ginkgo/pkg/util/common.go
@@ -40,11 +40,7 @@ func GetPathAndFileName(projPath, path string) (dir string, file string, err err
 		return "", "", errors.New("path is empty")
 	}
 	absPath := filepath.Join(projPath, path)
-	fileInfo, err := os.Stat(absPath)
-	if err != nil {
-		return "", "", err
-	}
-	if fileInfo.IsDir() {
+	if !strings.HasSuffix(absPath, ".go") {
 		return path, "", nil
 	} else {
 		relPath, err := filepath.Rel(projPath, filepath.Dir(absPath))

--- a/ginkgo/testtool.yaml
+++ b/ginkgo/testtool.yaml
@@ -3,7 +3,7 @@ name: ginkgo
 nameZh: Ginkgo自动化测试工具
 lang: golang
 langType: COMPILED
-version: '0.2.14'
+version: '0.2.16'
 description: Ginkgo自动化测试工具
 defaultBaseImage: golang:1.22
 scaffoldRepo: https://github.com/OpenTestSolar/testtool-scaffold-ginkgo
@@ -28,8 +28,10 @@ parameterDefs:
     choices:
       - desc: 是
         value: 'true'
+        displayName: 是
       - desc: 否
         value: 'false'
+        displayName: 否
     inputWidget: choices
   - name: withLabels
     default: "false"
@@ -38,8 +40,10 @@ parameterDefs:
     choices:
       - desc: 是
         value: 'true'
+        displayName: 是
       - desc: 否
         value: 'false'
+        displayName: 否
     inputWidget: choices
   - name: splitBySpace
     default: "false"
@@ -48,8 +52,10 @@ parameterDefs:
     choices:
       - desc: 是
         value: 'true'
+        displayName: 是
       - desc: 否
         value: 'false'
+        displayName: 否
     inputWidget: choices
   - name: concurrentBuild
     default: "false"
@@ -58,8 +64,10 @@ parameterDefs:
     choices:
       - desc: 是
         value: 'true'
+        displayName: 是
       - desc: 否
         value: 'false'
+        displayName: 否
     inputWidget: choices
   - name: compressBinary
     default: "false"
@@ -68,8 +76,10 @@ parameterDefs:
     choices:
       - desc: 是
         value: 'true'
+        displayName: 是
       - desc: 否
         value: 'false'
+        displayName: 否
     inputWidget: choices
 supportOS:
   - windows


### PR DESCRIPTION
1. 加载用例阶段允许动态构建二进制文件
2. 加载用例阶段允许不使用二进制文件而是直接调用ginkgo命令行加载用例
3. 修复加载用例阶段输出用例报告文件路径问题
4. 执行用例阶段运行在只有二进制文件而没有实际用例文件的情况下执行
5. 执行用例阶段通过focus参数指定执行用例时去除后缀`$`