### PR TITLE
支持在通过二进制形式执行用例时将额外命令中传入的ginkgo相关参数添加ginkgo前缀

### DIFF
--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -33,6 +33,10 @@ func TestGenarateCommandLine(t *testing.T) {
 	expected = "suite.test --ginkgo.v --ginkgo.no-color --ginkgo.trace --ginkgo.json-report=\"output.json\" --ginkgo.always-emit-ginkgo-writer --ginkgo.focus=\"case01$|case02$\" --ginkgo.label-filter \"( label01||label02)\""
 	cmdline = genarateCommandLine(extraArgs, jsonFileName, projPath, pkgBin, tcNames, false)
 	assert.Equal(t, expected, cmdline, "should return the expected command line")
+	extraArgs = `--label-filter "( label01||label02)" --timeout 5h --procs 3`
+	expected = `suite.test --ginkgo.v --ginkgo.no-color --ginkgo.trace --ginkgo.json-report="output.json" --ginkgo.always-emit-ginkgo-writer --ginkgo.focus="case01$|case02$" --ginkgo.label-filter "( label01||label02)" --ginkgo.timeout "5h" --procs "3"`
+	cmdline = genarateCommandLine(extraArgs, jsonFileName, projPath, pkgBin, tcNames, false)
+	assert.Equal(t, expected, cmdline, "should convert ginkgo flags to --ginkgo. prefix for binary")
 	extraArgs = ""
 	expected = "suite.test --ginkgo.v --ginkgo.no-color --ginkgo.trace --ginkgo.json-report=\"output.json\" --ginkgo.always-emit-ginkgo-writer --ginkgo.focus=\"case01$|case02$\""
 	cmdline = genarateCommandLine(extraArgs, jsonFileName, projPath, pkgBin, tcNames, false)

--- a/pkg/runner/v2_runner.go
+++ b/pkg/runner/v2_runner.go
@@ -29,6 +29,69 @@ func parseExtraArgs(extraArgs string) (*cmdpkg.CommandArgs, error) {
 	return cmdpkg.NewCmdArgsParseByCmdLine(extraArgs)
 }
 
+var ginkgoBinaryFlags = map[string]bool{
+	"always-emit-ginkgo-writer": true,
+	"dry-run":                   true,
+	"fail-fast":                 true,
+	"fail-on-empty":             true,
+	"fail-on-pending":           true,
+	"flake-attempts":            true,
+	"focus":                     true,
+	"focus-file":                true,
+	"force-newlines":            true,
+	"github-output":             true,
+	"gojson-report":             true,
+	"grace-period":              true,
+	"json-report":               true,
+	"junit-report":              true,
+	"label-filter":              true,
+	"no-color":                  true,
+	"output-interceptor-mode":   true,
+	"parallel.host":             true,
+	"parallel.process":          true,
+	"parallel.total":            true,
+	"poll-progress-after":       true,
+	"poll-progress-interval":    true,
+	"randomize-all":             true,
+	"randomize-suites":          true,
+	"sem-ver-filter":            true,
+	"seed":                      true,
+	"show-node-events":          true,
+	"silence-skips":             true,
+	"skip":                      true,
+	"skip-file":                 true,
+	"succinct":                  true,
+	"source-root":               true,
+	"teamcity-report":           true,
+	"timeout":                   true,
+	"trace":                     true,
+	"v":                         true,
+	"vv":                        true,
+}
+
+func convertExtraArgsForBinary(extraArgs string) string {
+	if extraArgs == "" {
+		return ""
+	}
+	cmdArgs, err := cmdpkg.NewCmdArgsParseByCmdLine(extraArgs)
+	if err != nil {
+		log.Printf("Parse extra args [%s] error: %v", extraArgs, err)
+		return extraArgs
+	}
+	for _, arg := range cmdArgs.Args {
+		if arg.Key == "" {
+			continue
+		}
+		if strings.HasPrefix(arg.Key, "--") && !strings.HasPrefix(arg.Key, "--ginkgo.") {
+			flagName := strings.TrimPrefix(arg.Key, "--")
+			if ginkgoBinaryFlags[flagName] {
+				arg.Key = "--ginkgo." + flagName
+			}
+		}
+	}
+	return cmdArgs.GenerateCmdLineStr()
+}
+
 func genarateCommandLine(extraArgs, jsonFileName, projPath, pkgBin string, tcNames []string, hasClient bool) string {
 	if hasClient {
 		defaultCmdLine := fmt.Sprintf("ginkgo --v --no-color --trace --json-report %s --output-dir %s --always-emit-ginkgo-writer", jsonFileName, projPath)
@@ -54,6 +117,7 @@ func genarateCommandLine(extraArgs, jsonFileName, projPath, pkgBin string, tcNam
 		cmdline := cmdArgs.GenerateCmdLineStr()
 		return cmdline
 	} else {
+		extraArgs = convertExtraArgsForBinary(extraArgs)
 		if extraArgs == "" {
 			return pkgBin + fmt.Sprintf(` --ginkgo.v --ginkgo.no-color --ginkgo.trace --ginkgo.json-report="%s" --ginkgo.always-emit-ginkgo-writer --ginkgo.focus="%s"`, jsonFileName, cmdpkg.GenTestCaseFocusName(tcNames))
 		} else {

--- a/testtool.yaml
+++ b/testtool.yaml
@@ -3,7 +3,7 @@ name: ginkgo
 nameZh: Ginkgo自动化测试工具
 lang: golang
 langType: COMPILED
-version: '0.2.64'
+version: '0.2.65'
 description: Ginkgo自动化测试工具
 defaultBaseImage: golang:1.22
 scaffoldRepo: https://github.com/OpenTestSolar/testtool-scaffold-ginkgo


### PR DESCRIPTION
支持在通过二进制形式执行用例时将额外命令中传入的ginkgo相关参数添加ginkgo前缀